### PR TITLE
Replaced **kwargs with *args in the middleware initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+Changed
+- Replaced **kwargs with *args in the middleware initializer
+
 ## [1.0.0.rc9]
 Changed
 - Added message if migration does not exist

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    cyclone_lariat (1.0.0)
+    cyclone_lariat (1.1.0)
       aws-sdk-sns
       aws-sdk-sqs
       dry-cli (~> 0.6)

--- a/README.md
+++ b/README.md
@@ -783,11 +783,12 @@ class Receiver
     # Options dataset, errors_notifier and message_notifier is optionals.
     # If you dont define notifiers - middleware does not notify
     # If you dont define dataset - middleware does not store events in db
-    chain.add CycloneLariat::Middleware,
-              dataset: DB[:events],
-              errors_notifier:  LunaPark::Notifiers::Sentry.new,
-              message_notifier: LunaPark::Notifiers::Log.new(min_lvl: :debug, format: :pretty_json),
-              before_save: -> { |message|  message.data[:password] = nil }
+    chain.add CycloneLariat::Middleware, {
+      dataset: DB[:events],
+      errors_notifier:  LunaPark::Notifiers::Sentry.new,
+      message_notifier: LunaPark::Notifiers::Log.new(min_lvl: :debug, format: :pretty_json),
+      before_save: -> { |message|  message.data[:password] = nil }
+    }
   end
 
   class UserIsNotRegistered < LunaPark::Errors::Business

--- a/lib/cyclone_lariat/middleware.rb
+++ b/lib/cyclone_lariat/middleware.rb
@@ -10,12 +10,14 @@ module CycloneLariat
   class Middleware
     attr_reader :config
 
-    def initialize(errors_notifier: nil, message_notifier: nil, before_save: nil, repo: Repo::InboxMessages, **options)
-      @config           = CycloneLariat::Options.wrap(options).merge!(CycloneLariat.config)
+    def initialize(args = {})
+      @message_notifier = args.delete(:message_notifier)
+      @errors_notifier  = args.delete(:errors_notifier)
+      @before_save      = args.delete(:before_save)
+
+      repo              = args.delete(:repo) || CycloneLariat::Repo::InboxMessages
+      @config           = CycloneLariat::Options.wrap(args).merge!(CycloneLariat.config)
       @events_repo      = repo.new(**@config.to_h)
-      @message_notifier = message_notifier
-      @errors_notifier  = errors_notifier
-      @before_save      = before_save
     end
 
     def call(_worker_instance, queue, _sqs_msg, body, &block)

--- a/lib/cyclone_lariat/version.rb
+++ b/lib/cyclone_lariat/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CycloneLariat
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/lib/cyclone_lariat/middleware_spec.rb
+++ b/spec/lib/cyclone_lariat/middleware_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CycloneLariat::Middleware do
     let(:notifier) { instance_double(LunaPark::Notifiers::Log, error: nil, warning: nil) }
 
     context 'when message_notifier is defined' do
-      let(:middleware) { described_class.new(message_notifier: notifier, driver: :sequel) }
+      let(:middleware) { described_class.new({ message_notifier: notifier, driver: :sequel }) }
 
       it 'should write INFO log message' do
         expect(notifier).to receive(:info).with(
@@ -37,7 +37,7 @@ RSpec.describe CycloneLariat::Middleware do
     end
 
     context 'when errors_notifier is defined' do
-      let(:middleware) { described_class.new(errors_notifier: notifier, driver: :sequel) }
+      let(:middleware) { described_class.new({ errors_notifier: notifier, driver: :sequel }) }
 
       context 'no any one exception is handled' do
         it 'should not write log message' do
@@ -111,7 +111,7 @@ RSpec.describe CycloneLariat::Middleware do
       let(:dataset) { double }
       let(:messages_repo) { instance_double CycloneLariat::Repo::InboxMessages, disabled?: false, find: event }
       let(:messages_repo_class) { class_double(CycloneLariat::Repo::InboxMessages, new: messages_repo) }
-      let(:middleware) { described_class.new(inbox_dataset: dataset, repo: messages_repo_class) }
+      let(:middleware) { described_class.new({ inbox_dataset: dataset, repo: messages_repo_class }) }
       let(:event) { instance_double CycloneLariat::Messages::V1::Event, processed?: true }
 
       context 'when event is already exists in dataset' do
@@ -157,7 +157,7 @@ RSpec.describe CycloneLariat::Middleware do
       context 'when before_save hook is defined' do
         let(:on_before_save) { double(call: true) }
         let(:messages_repo) { instance_double CycloneLariat::Repo::InboxMessages, disabled?: false, find: nil, create: nil, processed!: true }
-        let(:middleware) { described_class.new(inbox_dataset: dataset, repo: messages_repo_class, before_save: on_before_save) }
+        let(:middleware) { described_class.new({ inbox_dataset: dataset, repo: messages_repo_class, before_save: on_before_save }) }
 
         it 'should call the hook' do
           expect(on_before_save).to receive(:call)
@@ -167,7 +167,7 @@ RSpec.describe CycloneLariat::Middleware do
     end
 
     context 'when dataset is not defined' do
-      let(:middleware) { described_class.new(inbox_dataset: nil, driver: :sequel) }
+      let(:middleware) { described_class.new({ inbox_dataset: nil, driver: :sequel }) }
 
       it { is_expected.to be :result }
 
@@ -192,7 +192,7 @@ RSpec.describe CycloneLariat::Middleware do
         end
       end
 
-      let(:middleware) { described_class.new(inbox_dataset: nil) }
+      let(:middleware) { described_class.new({ inbox_dataset: nil }) }
 
       it { is_expected.to be true }
 


### PR DESCRIPTION
Shoryuken uses positional args, see https://github.com/ruby-shoryuken/shoryuken/blob/main/lib/shoryuken/middleware/chain.rb#L116